### PR TITLE
Add builds folder to skip_render

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ archive_dir: archives
 category_dir: categories
 code_dir: downloads/code
 i18n_dir: :lang
-skip_render:
+skip_render: "source/builds/*"
 
 # Writing
 new_post_name: :title.md # File name of new posts


### PR DESCRIPTION
This will allow us to set up Arduino OTA updates using source/builds/latest.version and source/builds/latest.bin